### PR TITLE
fix: read nonce value from relay response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
   test:
     timeout-minutes: 10
-    runs-on: "buildjet-4vcpu-ubuntu-2204"
+    runs-on: "ubuntu-latest"
 
     strategy:
       matrix:

--- a/packages/auth-kit/CHANGELOG.md
+++ b/packages/auth-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/auth-kit
 
+## 0.0.37
+
+### Patch Changes
+
+- Fix: read nonce from return value
+
 ## 0.0.36
 
 ### Patch Changes

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-kit",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "type": "module",
   "main": "./dist/auth-kit.js",
   "types": "./dist/auth-kit.d.ts",

--- a/packages/auth-kit/src/hooks/useCreateChannel.ts
+++ b/packages/auth-kit/src/hooks/useCreateChannel.ts
@@ -61,15 +61,15 @@ export function useCreateChannel({
         setError(createChannelError);
         onError?.(createChannelError);
       } else {
-        const { channelToken, url } = data;
+        const { channelToken, url, nonce } = data;
         setChannelToken(channelToken);
         setUrl(url);
-        setNonce(nonceVal);
+        setNonce(nonce);
 
         const qrCodeUri = await QRCode.toDataURL(url, { width: 360 });
         setqrCodeUri(qrCodeUri);
         setIsSuccess(true);
-        onSuccess?.({ channelToken, url, qrCodeUri, nonce: nonceVal });
+        onSuccess?.({ channelToken, url, qrCodeUri, nonce });
       }
     }
   }, [appClient, siweUri, domain, channelToken, customNonce, notBefore, expirationTime, requestId, onError, onSuccess]);


### PR DESCRIPTION
## Change Summary

I accidentally undid this fix when working on renaming. The server returns the nonce in its create channel response, whether it was passed through from the frontend or generated server side, we can read it from there.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed