### PR TITLE
fix: allow port in domain

### DIFF
--- a/.changeset/wise-horses-repeat.md
+++ b/.changeset/wise-horses-repeat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": patch
+---
+
+fix: allow port in domain

--- a/apps/relay/src/schemas.ts
+++ b/apps/relay/src/schemas.ts
@@ -8,7 +8,7 @@ export const createChannelRequestSchema = {
     },
     domain: {
       type: "string",
-      format: "hostname",
+      pattern: "^[a-zA-Z0-9.-]+(:[0-9]+)?$",
     },
     nonce: {
       type: "string",

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -167,8 +167,17 @@ describe("relay server", () => {
       expect(response.status).toBe(400);
       expect(response.data).toStrictEqual({
         error: "Validation error",
-        message: 'body/domain must match format "hostname"',
+        message: 'body/domain must match pattern "^[a-zA-Z0-9.-]+(:[0-9]+)?$"',
       });
+    });
+
+    test("domain with port", async () => {
+      const response = await http.post(getFullUrl("/v1/channel"), {
+        ...channelParams,
+        domain: "localhost:3000",
+      });
+
+      expect(response.status).toBe(201);
     });
 
     test("open channel error", async () => {


### PR DESCRIPTION
## Change Summary

Allow optional port in domain.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
