### PR TITLE
fix: check for window.location

### DIFF
--- a/.changeset/angry-hornets-divide.md
+++ b/.changeset/angry-hornets-divide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": patch
+---
+
+fix: check window.location for RN compatibility

--- a/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
+++ b/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
@@ -35,11 +35,15 @@ export interface AuthKitContextValues {
   onSignOut: () => void;
 }
 
+const domainDefaults = window.location ? {
+  domain: window.location.host,
+  siweUri: window.location.href
+} : {};
+
 const configDefaults = {
   relay: "https://relay.farcaster.xyz",
   version: "v1",
-  domain: window.location.host,
-  siweUri: window.location.href
+  ...domainDefaults
 };
 
 export const AuthKitContext = createContext<AuthKitContextValues>({


### PR DESCRIPTION
## Motivation

`window.location` is not defined in a React Native environment.

## Change Summary

Check for `window.location` in `AuthKitProvider`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed