### PR TITLE
feat: make provider config optional

### DIFF
--- a/.changeset/tiny-snails-burn.md
+++ b/.changeset/tiny-snails-burn.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": patch
+---
+
+feat: optional provider config prop

--- a/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
+++ b/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
@@ -59,7 +59,7 @@ export function AuthKitProvider({
   config,
   children,
 }: {
-  config: AuthKitConfig;
+  config?: AuthKitConfig;
   children: ReactNode;
 }) {
   const [appClient, setAppClient] = useState<AppClient>();


### PR DESCRIPTION
## Motivation

All the configuration options on `AuthKitProvider` config are now optional.

## Change Summary

Make the `config` prop optional on `AuthKitProvider`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
