### PR TITLE
fix: verification fix

### DIFF
--- a/apps/relay/CHANGELOG.md
+++ b/apps/relay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/auth-relay
 
+## 0.0.8
+
+### Patch Changes
+
+- fix: handle new verification message name
+
 ## 0.0.7
 
 ### Patch Changes

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-relay",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Farcaster Auth relay server",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
## Change Summary

Hubble 1.9.4 introduced a backwards incompatible rename of verifications from `VerificationAddEthAddress` to `VerificationAddAddress`. Add a check for both for now in the relay. (We should probably use GRPC here).

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
