### PR TITLE
fix: memoize signIn and signOut

### DIFF
--- a/.changeset/sixty-meals-beg.md
+++ b/.changeset/sixty-meals-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": patch
+---
+
+fix: memoize signIn/signOut in useSignIn

--- a/.changeset/sixty-meals-beg.md
+++ b/.changeset/sixty-meals-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/auth-kit": patch
----
-
-fix: memoize signIn/signOut in useSignIn

--- a/packages/auth-kit/CHANGELOG.md
+++ b/packages/auth-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/auth-kit
 
+## 0.2.1
+
+### Patch Changes
+
+- 1bee0fb: fix: memoize signIn/signOut in useSignIn
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-kit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "./dist/auth-kit.js",
   "types": "./dist/auth-kit.d.ts",

--- a/packages/auth-kit/src/hooks/useSignIn.ts
+++ b/packages/auth-kit/src/hooks/useSignIn.ts
@@ -1,5 +1,5 @@
 import { AuthClientError, StatusAPIResponse } from "@farcaster/auth-client";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 import useAppClient from "./useAppClient";
 import useCreateChannel, { UseCreateChannelArgs } from "./useCreateChannel";
@@ -74,14 +74,14 @@ export function useSignIn(args: UseSignInArgs) {
   const isError = isCreateChannelError || isWatchStatusError || isVerifyError;
   const error = createChannelError || watchStatusError || verifyError;
 
-  const signIn = () => {
+  const signIn = useCallback(() => {
     watch();
-  };
+  }, [watch]);
 
-  const signOut = () => {
+  const signOut = useCallback(() => {
     onSignOut();
     reset();
-  };
+  }, [onSignOut, reset]);
 
   useEffect(() => {
     if (isSuccess && statusData && validSignature) {


### PR DESCRIPTION
## Change Summary

Memoize `signIn` and `signOut` functions returned from `useSignIn` hook.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
