### PR TITLE
fix: make StatusApiResponse type discrimitive union

### DIFF
--- a/packages/auth-client/src/actions/app/status.ts
+++ b/packages/auth-client/src/actions/app/status.ts
@@ -9,20 +9,25 @@ export interface StatusArgs {
 
 export type StatusResponse = AsyncUnwrapped<HttpResponse<StatusAPIResponse>>;
 
-export interface StatusAPIResponse {
-  state: "pending" | "completed";
-  nonce: string;
-  url: string;
-  message?: string;
-  signature?: `0x${string}`;
-  fid?: number;
-  username?: string;
-  bio?: string;
-  displayName?: string;
-  pfpUrl?: string;
-  verifications?: Hex[];
-  custody?: Hex;
-}
+export type StatusAPIResponse =
+  | {
+      state: "pending";
+      nonce: string;
+    }
+  | {
+      state: "completed";
+      nonce: string;
+      url: string;
+      message: string;
+      signature: `0x${string}`;
+      fid: number;
+      username: string;
+      bio: string;
+      displayName: string;
+      pfpUrl: string;
+      verifications?: Hex[];
+      custody?: Hex;
+    };
 
 const path = "channel/status";
 

--- a/packages/auth-client/src/actions/app/status.ts
+++ b/packages/auth-client/src/actions/app/status.ts
@@ -10,7 +10,7 @@ export interface StatusArgs {
 export type StatusResponse = AsyncUnwrapped<HttpResponse<StatusAPIResponse>>;
 
 export type StatusAPIResponse =
-  | {
+  | { 
       state: "pending";
       nonce: string;
     }


### PR DESCRIPTION
## Motivation

I was adding Farcaster login at work and found that the permanently optional types to be incorrect. I think this type reflects better the two states that can be returned.

## Change Summary

Convert StatusApiResponse type discrimitive union to allow for two type states once a single check on state has been made

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ x ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ x ] PR has a changeset
- [ x ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ x ] PR includes documentation if necessary
- [ x ] All commits have been signed

