### PR TITLE
fix: make StatusApiResponse type a discrimitive union

### DIFF
--- a/packages/auth-client/src/actions/app/status.ts
+++ b/packages/auth-client/src/actions/app/status.ts
@@ -9,17 +9,20 @@ export interface StatusArgs {
 
 export type StatusResponse = AsyncUnwrapped<HttpResponse<StatusAPIResponse>>;
 
-export interface StatusAPIResponse {
-  state: "pending" | "completed";
+export type StatusAPIResponse = {
+  state: "pending";
+  nonce: string;
+} | {
+  state: "completed";
   nonce: string;
   url: string;
-  message?: string;
-  signature?: `0x${string}`;
-  fid?: number;
-  username?: string;
-  bio?: string;
-  displayName?: string;
-  pfpUrl?: string;
+  message: string;
+  signature: `0x${string}`;
+  fid: number;
+  username: string;
+  bio: string;
+  displayName: string;
+  pfpUrl: string;
   verifications?: Hex[];
   custody?: Hex;
 }


### PR DESCRIPTION
## Motivation

I was working on integrating farcaster at work and i found that this type was giving optional types even after verify that status === completed. This discrimitive union type allows for required types once status has been verified.

## Change Summary

Convert StatusApiResponse type to discrimitive union

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed


