### PR TITLE
feat: improve QR code legibility

### DIFF
--- a/.changeset/green-hotels-explain.md
+++ b/.changeset/green-hotels-explain.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": minor
+---
+
+feat: improve QR code legibility

--- a/packages/auth-kit/src/components/FarcasterLogo.tsx
+++ b/packages/auth-kit/src/components/FarcasterLogo.tsx
@@ -12,6 +12,7 @@ export function FarcasterLogo({
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
+      viewBox="0 0 22 20"
       fill="none"
     >
       <title>Farcaster logo</title>

--- a/packages/auth-kit/src/components/QRCode.tsx
+++ b/packages/auth-kit/src/components/QRCode.tsx
@@ -40,8 +40,8 @@ export function QRCode({
   const padding = "20";
   const size = sizeProp - parseInt(padding, 10) * 2;
 
-  const dots = useMemo(() => {
-    const dots: ReactElement[] = [];
+  const squares = useMemo(() => {
+    const squares: ReactElement[] = [];
     const matrix = generateMatrix(uri, ecl);
     const cellSize = size / matrix.length;
     const qrList = [
@@ -54,7 +54,7 @@ export function QRCode({
       const x1 = (matrix.length - 7) * cellSize * x;
       const y1 = (matrix.length - 7) * cellSize * y;
       for (let i = 0; i < 3; i++) {
-        dots.push(
+        squares.push(
           <rect
             fill={i % 2 !== 0 ? "white" : "black"}
             height={cellSize * (7 - i * 2)}
@@ -91,13 +91,14 @@ export function QRCode({
                 j < matrixMiddleEnd
               )
             ) {
-              dots.push(
-                <circle
-                  cx={i * cellSize + cellSize / 2}
-                  cy={j * cellSize + cellSize / 2}
+              squares.push(
+                <rect
                   fill="black"
-                  key={`circle-${i}-${j}`}
-                  r={cellSize / 3} // calculate size of single dots
+                  height={cellSize - 0.5}
+                  key={`square-${i}-${j}`}
+                  width={cellSize - 0.5}
+                  x={i * cellSize}
+                  y={j * cellSize}
                 />
               );
             }
@@ -106,7 +107,7 @@ export function QRCode({
       });
     });
 
-    return dots;
+    return squares;
   }, [ecl, logoSize, logoMargin, size, uri]);
 
   const logoPosition = size / 2 - logoSize / 2;
@@ -135,7 +136,7 @@ export function QRCode({
             </clipPath>
           </defs>
           <rect fill="transparent" height={size} width={size} />
-          {dots}
+          {squares}
         </svg>
       </div>
     </div>

--- a/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.tsx
+++ b/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.tsx
@@ -32,6 +32,7 @@ export function QRCodeDialog({
               height={18}
               fill="none"
             >
+              <title>Sign in With Farcaster</title>
               <path
                 fill="rgba(0,0,0,0.5)"
                 fillRule="evenodd"
@@ -61,7 +62,7 @@ export function QRCodeDialog({
                   marginBottom: 12,
                 }}
               >
-                <QRCode uri={url} size={264} logoSize={22} logoMargin={12} />
+                <QRCode uri={url} size={300} logoSize={28} logoMargin={16} />
               </div>
               <div style={{ display: "flex", justifyContent: "center" }}>
                 <Button
@@ -81,6 +82,7 @@ export function QRCodeDialog({
                     height={18}
                     fill="none"
                   >
+                    <title>Sign in With Farcaster QR Code</title>
                     <path
                       fill="#7C65C1"
                       fillRule="evenodd"


### PR DESCRIPTION
## Motivation

The default AuthKit QR code can be difficult to scan.

## Change Summary

Remove rounded dots, bump up default QR code size:

<img width="355" alt="Screenshot 2024-05-10 at 7 40 50 PM" src="https://github.com/farcasterxyz/auth-monorepo/assets/109845214/77ee5ed4-34c6-4d6b-ba35-69cdbfc4f129">
<img width="365" alt="Screenshot 2024-05-10 at 7 41 11 PM" src="https://github.com/farcasterxyz/auth-monorepo/assets/109845214/b64b8465-f260-446f-84ce-0fc1cdb0570d">

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
