### PR TITLE
Added custom button component for the SignInButton component

### DIFF
--- a/packages/auth-kit/README.md
+++ b/packages/auth-kit/README.md
@@ -132,6 +132,30 @@ export const SignIn = ({ nonce }: { nonce: string }) => {
 };
 ```
 
+#### Customizing the `SignInButton` button component
+
+```tsx
+import { SignInButton } from "@farcaster/auth-kit";
+
+export const SignIn = ({ nonce }: { nonce: string }) => {
+  return (
+    <SignInButton
+      nonce={nonce}
+      onSuccess={({ fid, username }) =>
+        console.log(`Hello, ${username}! Your fid is ${fid}.`)
+      }
+
+      Button={({ onClick }) => (
+        <button onClick={onClick}>
+            My custom sign in with farcaster button.
+            Only prop to ensure is onClick
+        </button>
+      )}
+    />
+  );
+};
+```
+
 #### Props
 
 | Prop               | Type                                | Required | Description                                                                         | Default              |

--- a/packages/auth-kit/src/components/SignInButton/SignInButton.tsx
+++ b/packages/auth-kit/src/components/SignInButton/SignInButton.tsx
@@ -11,12 +11,14 @@ type SignInButtonProps = UseSignInArgs & {
   onSignOut?: () => void;
   debug?: boolean;
   hideSignOut?: boolean;
+  Button?: (props: { onClick: () => void }) => JSX.Element;
 };
 
 export function SignInButton({
   debug,
   hideSignOut,
   onSignOut,
+  Button,
   ...signInArgs
 }: SignInButtonProps) {
   const { onSuccess, onStatusResponse, onError } = signInArgs;
@@ -103,7 +105,10 @@ export function SignInButton({
         />
       ) : (
         <>
-          <ActionButton onClick={onClick} label="Sign in" />
+        { Button
+            ? <Button onClick={onClick} />
+            : <ActionButton onClick={onClick} label="Sign in" />
+        }
           {url && (
             <QRCodeDialog
               open={showDialog && !isMobile()}


### PR DESCRIPTION
## Motivation

The `SignInButton` is ready to go, but does not allow much customization. 

This PR adds the ability to pass in your own button component to be the 'Sign In with Farcaster' button and still work with the other built in components and functionality.

## Change Summary

Added optional prop `Button?: (props: { onClick: () => void }) => JSX.Element;` to the `SignInButton` and then will conditionally use the `Button` prop if given, or default fallback to the `<ActionButton  ... `

#### Customizing the `SignInButton` button component

```tsx
import { SignInButton } from "@farcaster/auth-kit";

export const SignIn = ({ nonce }: { nonce: string }) => {
  return (
    <SignInButton
      nonce={nonce}
      onSuccess={({ fid, username }) =>
        console.log(`Hello, ${username}! Your fid is ${fid}.`)
      }

      Button={({ onClick }) => (
        <button onClick={onClick}>
            My custom sign in with farcaster button.
            Only prop to ensure is onClick
        </button>
      )}
    />
  );
};
```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [ ] All commits have been signed

## Additional Context

N/A