### PR TITLE
feat: add clearer sign up CTA to modal

### DIFF
--- a/.changeset/violet-books-heal.md
+++ b/.changeset/violet-books-heal.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": patch
+---
+
+feat: add sign up CTA to modal

--- a/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.css.ts
+++ b/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.css.ts
@@ -23,6 +23,17 @@ export const instructions = style({
   color: "rgba(0, 0, 0, 0.5)",
 });
 
+export const signUp = style({
+  textDecoration: "none",
+  color: "#7C65C1",
+});
+
+export const createAccount = style({
+  marginTop: 8,
+  fontSize: 15.5,
+  color: "rgba(0, 0, 0, 0.5)",
+});
+
 export const qrCodeImage = style({
   maxWidth: 480,
   width: "100%",

--- a/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.tsx
+++ b/packages/auth-kit/src/components/QRCodeDialog/QRCodeDialog.tsx
@@ -1,6 +1,12 @@
 import { AuthClientError } from "@farcaster/auth-client";
 import { Dialog } from "../Dialog/index.ts";
-import { body, siwfHeading, instructions } from "./QRCodeDialog.css.ts";
+import {
+  body,
+  siwfHeading,
+  instructions,
+  createAccount,
+  signUp
+} from "./QRCodeDialog.css.ts";
 import { Button } from "../Button.tsx";
 import { QRCode } from "../QRCode.tsx";
 
@@ -53,6 +59,9 @@ export function QRCodeDialog({
               <div className={siwfHeading}>Sign in with Farcaster</div>
               <div className={instructions}>
                 Scan with your phone's camera to continue.
+              </div>
+              <div className={createAccount}>
+                <a className={signUp} href="https://warpcast.com/~/signup" target="_blank" rel="noreferrer">Need to create an account?</a>
               </div>
               <div
                 style={{


### PR DESCRIPTION
## Motivation

Add a clearer "Sign up" CTA to the sign in modal.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
