### PR TITLE
fix: change prop config from required to optional

### DIFF
--- a/.changeset/fluffy-weeks-impress.md
+++ b/.changeset/fluffy-weeks-impress.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-kit": patch
+---
+
+fix: change prop config from required to optional

--- a/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
+++ b/packages/auth-kit/src/components/AuthKitProvider/AuthKitProvider.tsx
@@ -61,7 +61,7 @@ export function AuthKitProvider({
   config,
   children,
 }: {
-  config: AuthKitConfig;
+  config?: AuthKitConfig;
   children: ReactNode;
 }) {
   const [appClient, setAppClient] = useState<AppClient>();


### PR DESCRIPTION
## Motivation

Because all the props are not required, I think it's unnecessary to pass `config` when I use the provider.

<img width="740" alt="image" src="https://github.com/farcasterxyz/auth-monorepo/assets/115673583/4012262b-8f2d-45f6-af59-23f76ae60103">


## Change Summary

Change types.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
