### PR TITLE
fix: run onResponse on success

### DIFF
--- a/.changeset/soft-rockets-doubt.md
+++ b/.changeset/soft-rockets-doubt.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-client": patch
+---
+
+fix: call onResponse before return

--- a/packages/auth-client/src/clients/transports/http.ts
+++ b/packages/auth-client/src/clients/transports/http.ts
@@ -25,7 +25,7 @@ const defaultPollOpts = {
   interval: 1000,
   timeout: 10000,
   successCode: 200,
-  onResponse: () => {},
+  onResponse: () => { },
 };
 
 export const get = async <ResponseDataType>(
@@ -91,9 +91,9 @@ export const poll = async <ResponseDataType>(
     if (res.isOk()) {
       const { response } = res.value;
       if (response.status === successCode) {
+        onResponse(res.value);
         return ok(res.value);
       }
-      onResponse(res.value);
       await new Promise((resolve) => setTimeout(resolve, interval));
     } else {
       return err(res.error);


### PR DESCRIPTION
## Motivation

`onResponse` runs after the return statement hence doesn't run on the success condition.

## Change Summary

call `onReponse` before returning from the function

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
