### PR TITLE
feat: add option to pass client url when initializing relayer channel

### DIFF
--- a/apps/relay/src/env.ts
+++ b/apps/relay/src/env.ts
@@ -9,7 +9,7 @@ export const REDIS_URL = process.env["REDIS_URL"] || "redis://localhost:6379";
 export const RELAY_SERVER_PORT = Number(process.env["RELAY_SERVER_PORT"] || "8000");
 export const RELAY_SERVER_HOST = process.env["RELAY_SERVER_HOST"] || "localhost";
 
-export const URL_BASE =
+export const DEFAULT_CLIENT_URL_BASE =
   process.env["URL_BASE"] || process.env["CONNECT_URI_BASE"] || "https://warpcast.com/~/sign-in-with-farcaster";
 
 export const HUB_URL = process.env["HUB_URL"] || "https://nemes.farcaster.xyz:2281";

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -1,6 +1,6 @@
 import { FastifyError, FastifyReply, FastifyRequest } from "fastify";
 import type { Hex } from "viem";
-import { AUTH_KEY, URL_BASE } from "./env";
+import { AUTH_KEY, DEFAULT_CLIENT_URL_BASE } from "./env";
 import { generateNonce } from "siwe";
 
 export type CreateChannelRequest = {
@@ -47,7 +47,7 @@ const constructUrl = (
 ): string => {
   const params = { channelToken, nonce, ...extraParams };
   const query = new URLSearchParams(params);
-  return `${clientUrl ?? URL_BASE}?${query.toString()}`;
+  return `${clientUrl ?? DEFAULT_CLIENT_URL_BASE}?${query.toString()}`;
 };
 
 export async function createChannel(request: FastifyRequest<{ Body: CreateChannelRequest }>, reply: FastifyReply) {

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -11,6 +11,7 @@ export type CreateChannelRequest = {
   expirationTime?: string;
   requestId?: string;
   redirectUrl?: string;
+  clientUrl?: string;
 };
 
 export type AuthenticateRequest = {
@@ -39,10 +40,14 @@ export type RelaySession = {
   custody?: Hex;
 };
 
-const constructUrl = (channelToken: string, nonce: string, extraParams: CreateChannelRequest): string => {
+const constructUrl = (
+  channelToken: string,
+  nonce: string,
+  { clientUrl, ...extraParams }: CreateChannelRequest,
+): string => {
   const params = { channelToken, nonce, ...extraParams };
   const query = new URLSearchParams(params);
-  return `${URL_BASE}?${query.toString()}`;
+  return `${clientUrl ?? URL_BASE}?${query.toString()}`;
 };
 
 export async function createChannel(request: FastifyRequest<{ Body: CreateChannelRequest }>, reply: FastifyReply) {


### PR DESCRIPTION
[draft to explain the concept, not a fully baked PR]

## Motivation

As it currently exists, the only client supported by the Warpcast relay servers is the Warpcast app, redirecting all auth requests to `https://warpcast.com/~/sign-in-with-farcaster`. Apps like Supercast currently have no way to have other apps SIWF unless they export a seed phrase and import that into the Warpcast app.

This PR adds some light flexibility to this by allowing the implementing page to specify the target client URL

This PR does not address any larger issues around assembling a registry or require handling. It currently does not recommend any changes to AuthKit itself - implementation of passing in the client URL is up to individual implementers to start.

## Change Summary

Instead of pulling from env, channel creation is updated to support passing in a client URL when initializing the channel. An example of how this could be used:

```tsx
function initSignInWithFarcaster(clientUrl?: string) {
  const res = await axios.post('https://relay.farcaster.xyz/v1/channel', {
      ...,
      clientUrl
  });
  // 
  console.log(res.data.connectUri)
  // => https://api.supercast.xyz/siwf?channelToken=...
}

...

<button onClick={() => initSignInWithFarcaster()}>Sign in with Warpcast</button>
<button onClick={() => initSignInWithFarcaster("https://api.supercast.xyz/siwf"}>Sign in with Supercast</button>
```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [ ] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
