### PR TITLE
fix: login does not poll for status callback

### DIFF
--- a/packages/auth-kit/src/components/ActionButton/ActionButton.tsx
+++ b/packages/auth-kit/src/components/ActionButton/ActionButton.tsx
@@ -4,12 +4,14 @@ import { Button } from "../Button.tsx";
 export function ActionButton({
   label,
   onClick,
+  initializing
 }: {
   label: string;
   onClick: () => void;
+  initializing: boolean;
 }) {
   return (
-    <Button kind="primary" onClick={onClick}>
+    <Button kind="primary" onClick={onClick} disabled={initializing}>
       <FarcasterLogo height={20} fill="white" />
       <span style={{ marginLeft: 9 }}>{label}</span>
     </Button>

--- a/packages/auth-kit/src/components/SignInButton/SignInButton.tsx
+++ b/packages/auth-kit/src/components/SignInButton/SignInButton.tsx
@@ -103,7 +103,7 @@ export function SignInButton({
         />
       ) : (
         <>
-          <ActionButton onClick={onClick} label="Sign in" />
+          <ActionButton initializing={!url} onClick={onClick} label={'Sign in' }/>
           {url && (
             <QRCodeDialog
               open={showDialog && !isMobile()}

--- a/packages/auth-kit/src/components/styles.css.ts
+++ b/packages/auth-kit/src/components/styles.css.ts
@@ -36,6 +36,12 @@ export const button = {
   fontWeight: 600,
   display: "flex",
   alignItems: "center",
+
+  ":disabled": {
+    cursor: "not-allowed",
+    opacity: 0.75,
+  },
+  transition: "opacity 0.2s",
 };
 
 export const resetButton = style({


### PR DESCRIPTION
## Motivation

- Sign in fails frequently for me due to a race condition.
- When the Sign In button is clicked before the channel is established you cannot complete login.

### Repro steps

- Open network inspector,  Slow network down to 3g, 
- Load the page and click the sign in button immediately (before the channel is fully created)
- Once the qr code modal pops up, scan the qr code
**Expected**: sign in to complete
**Actual**: it sits at the qr code modal – if you check the network inspector, the polling for /status never starts.

See video for root cause and explanation: https://share.cleanshot.com/y9FnghMw


## Change Summary
Prevent the Sign In button from being clicked until a channel is established.

Alternate fixes considered:
- Don't reset state in useWatchStatus: can't reason about the scope of this change since consumed externally with many deps; disabling simpler.
- Call `signIn` after channel created: no async handle / callback for post channel creation so no where to block. too much to change.
- Remove isEnabled entirely and always poll: assumed its there cause you dont wanna spam network, but this would work too and not require waiting on the user side
 
See video: https://share.cleanshot.com/y9FnghMw


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [ ] All commits have been signed
