### PR TITLE
chore: remove deprecated routes

### DIFF
--- a/.changeset/late-dryers-appear.md
+++ b/.changeset/late-dryers-appear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": minor
+---
+
+chore: remove deprecated routes

--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -62,16 +62,6 @@ export class RelayServer {
           next();
         });
 
-        v1.register(async (publicRoutes, _opts, next) => {
-          await publicRoutes.register(rateLimit);
-          publicRoutes.post<{ Body: CreateChannelRequest }>(
-            "/connect",
-            { schema: { body: createChannelRequestSchema } },
-            createChannel,
-          );
-          next();
-        });
-
         v1.register((protectedRoutes, _opts, next) => {
           protectedRoutes.decorateRequest("channelToken", "");
           protectedRoutes.addHook("preHandler", async (request, reply) => {
@@ -87,8 +77,6 @@ export class RelayServer {
           protectedRoutes.post<{
             Body: AuthenticateRequest;
           }>("/connect/authenticate", { schema: { body: authenticateRequestSchema } }, authenticate);
-
-          protectedRoutes.get("/connect/status", status);
 
           protectedRoutes.post<{
             Body: AuthenticateRequest;


### PR DESCRIPTION
## Motivation

The `/connect/*` routes on the relay are deprecated. According to our logs, nobody is calling them. Warpcast is still calling `/connect/authenticate`, which we should update in a separate change.

## Change Summary

Remove `/connect/*` routes from relay server.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
