### PR TITLE
fix: move call to onResponse

### DIFF
--- a/packages/auth-client/src/actions/app/watchStatus.test.ts
+++ b/packages/auth-client/src/actions/app/watchStatus.test.ts
@@ -35,6 +35,6 @@ describe("status", () => {
     expect(res.response.status).toEqual(200);
     expect(res.data).toEqual({ state: "completed" });
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/auth-client/src/clients/transports/http.ts
+++ b/packages/auth-client/src/clients/transports/http.ts
@@ -90,8 +90,8 @@ export const poll = async <ResponseDataType>(
     const res = await get<ResponseDataType>(client, path, opts);
     if (res.isOk()) {
       const { response } = res.value;
+      onResponse(res.value);
       if (response.status === successCode) {
-        onResponse(res.value);
         return ok(res.value);
       }
       await new Promise((resolve) => setTimeout(resolve, interval));


### PR DESCRIPTION
## Motivation

#177 had the right idea, but we need to call `onResponse` on every response, not just success.

## Change Summary

Move `onResponse` outside success code check.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
