### PR TITLE
fix: set generated nonce in signature params

### DIFF
--- a/.changeset/long-islands-dream.md
+++ b/.changeset/long-islands-dream.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": patch
+---
+
+fix: set generated nonce in signature params

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -58,7 +58,7 @@ export async function createChannel(request: FastifyRequest<{ Body: CreateChanne
       nonce,
       url,
       connectUri: url,
-      signatureParams: request.body,
+      signatureParams: { ...request.body, nonce },
     });
     if (update.isOk()) {
       return reply.code(201).send({ channelToken, url, connectUri: url, nonce });

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -374,6 +374,7 @@ describe("relay server", () => {
       expect(nonce).toMatch(/[a-zA-Z0-9]{16}/);
       expect(rest).toStrictEqual({
         signatureParams: {
+          nonce,
           domain: "example.com",
           siweUri: "https://example.com",
         },


### PR DESCRIPTION
## Change Summary

Set generated nonce in `signatureParams`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed
