### PR TITLE
chore: remove deprecated /connect/authenticate route

### DIFF
--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -76,10 +76,6 @@ export class RelayServer {
 
           protectedRoutes.post<{
             Body: AuthenticateRequest;
-          }>("/connect/authenticate", { schema: { body: authenticateRequestSchema } }, authenticate);
-
-          protectedRoutes.post<{
-            Body: AuthenticateRequest;
           }>("/channel/authenticate", { schema: { body: authenticateRequestSchema } }, authenticate);
 
           protectedRoutes.get("/channel/status", status);


### PR DESCRIPTION
## Change Summary

Remove deprecated `/connect/authenticate` relay route.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
