### PR TITLE
feat: add request metadata to channel

### DIFF
--- a/.changeset/loud-readers-watch.md
+++ b/.changeset/loud-readers-watch.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/auth-client": patch
+"@farcaster/auth-relay": patch
+---
+
+add request metadata to channel

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -23,6 +23,11 @@ export type AuthenticateRequest = {
   pfpUrl: string;
 };
 
+export type SessionMetadata = {
+  ip: string;
+  userAgent: string;
+};
+
 export type RelaySession = {
   state: "pending" | "completed";
   nonce: string;
@@ -38,6 +43,7 @@ export type RelaySession = {
   verifications?: string[];
   custody?: Hex;
   signatureParams: CreateChannelRequest;
+  metadata: SessionMetadata;
 };
 
 const constructUrl = (channelToken: string, nonce: string, extraParams: CreateChannelRequest): string => {
@@ -59,6 +65,10 @@ export async function createChannel(request: FastifyRequest<{ Body: CreateChanne
       url,
       connectUri: url,
       signatureParams: { ...request.body, nonce },
+      metadata: {
+        userAgent: request.headers["user-agent"] ?? "Unknown",
+        ip: request.ip,
+      },
     });
     if (update.isOk()) {
       return reply.code(201).send({ channelToken, url, connectUri: url, nonce });

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -378,6 +378,10 @@ describe("relay server", () => {
           domain: "example.com",
           siweUri: "https://example.com",
         },
+        metadata: {
+          ip: "127.0.0.1",
+          userAgent: "axios/1.7.4",
+        },
       });
     });
 

--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -24,7 +24,7 @@ interface RelayServerConfig {
 }
 
 export class RelayServer {
-  app = fastify({ logger });
+  app = fastify({ logger, trustProxy: true });
   channels: ChannelStore<RelaySession>;
   addresses: AddressService;
 

--- a/packages/auth-client/src/actions/app/status.test.ts
+++ b/packages/auth-client/src/actions/app/status.test.ts
@@ -20,6 +20,10 @@ describe("status", () => {
       domain: "example.com",
       siweUri: "https://example.com/login",
     },
+    metadata: {
+      ip: "127.0.0.1",
+      userAgent: "Mozilla/5.0",
+    },
   };
 
   test("constructs API request", async () => {

--- a/packages/auth-client/src/actions/app/status.ts
+++ b/packages/auth-client/src/actions/app/status.ts
@@ -31,6 +31,10 @@ export interface StatusAPIResponse {
     requestId?: string;
     redirectUrl?: string;
   };
+  metadata: {
+    ip: string;
+    userAgent: string;
+  };
 }
 
 const path = "channel/status";

--- a/packages/auth-client/src/actions/auth/authenticate.test.ts
+++ b/packages/auth-client/src/actions/auth/authenticate.test.ts
@@ -24,6 +24,15 @@ describe("authenticate", () => {
   const statusResponseDataStub: AuthenticateAPIResponse = {
     state: "completed",
     nonce: "abcd1234",
+    signatureParams: {
+      nonce: "abcd1234",
+      siweUri: "https://example.com/login",
+      domain: "example.com",
+    },
+    metadata: {
+      ip: "127.0.0.1",
+      userAgent: "Mozilla/5.0",
+    },
     url: "https://warpcast.com/~/sign-in-with-farcaster?nonce=abcd1234[...]",
     message,
     signature,


### PR DESCRIPTION
## Motivation

To defend against “QR-jacking” attacks, pass the user agent and origin IP of the application opening the channel through the relay. Wallet clients can display this along with the sign in request, e.g. “requested from Chrome browser (Brooklyn, NY)” or similar.

## Change Summary

Add `metadata.ip` and `metadata.userAgent` to relay session body.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed
