### PR TITLE
chore: relax sign in URI validation

### DIFF
--- a/.changeset/sixty-buttons-poke.md
+++ b/.changeset/sixty-buttons-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-client": patch
+---
+
+allow channel token only in sign in URI


### PR DESCRIPTION
## Change Summary

Relax URL validation in `parseSignInURI` to allow URLs with channel token only.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed
