### PR TITLE
fix: bump relay timeouts

### DIFF
--- a/.changeset/popular-flies-joke.md
+++ b/.changeset/popular-flies-joke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": patch
+---
+
+fix: bump relay timeouts

--- a/apps/relay/src/addresses.ts
+++ b/apps/relay/src/addresses.ts
@@ -77,13 +77,13 @@ export class AddressService {
     const url = `${HUB_URL}/v1/verificationsByFid?fid=${fid}`;
     const fallbackUrl = `${HUB_FALLBACK_URL}/v1/verificationsByFid?fid=${fid}`;
 
-    return ResultAsync.fromPromise(this.http.get<VerificationsAPIResponse>(url, { timeout: 1000 }), (error) => {
+    return ResultAsync.fromPromise(this.http.get<VerificationsAPIResponse>(url, { timeout: 5000 }), (error) => {
       return new RelayError("unknown", error as Error);
     })
       .orElse(() => {
         return ResultAsync.fromPromise(
           this.http.get<VerificationsAPIResponse>(fallbackUrl, {
-            timeout: 3000,
+            timeout: 5000,
           }),
           (error) => {
             return new RelayError("unknown", error as Error);


### PR DESCRIPTION
## Motivation

Bump up hub request timeouts to 5 seconds.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed