### PR TITLE
feat: Use LOG_LEVEL when setting log level

### DIFF
--- a/.changeset/brown-geese-pretend.md
+++ b/.changeset/brown-geese-pretend.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": patch
+---
+
+fix: Allow log level to be configured via environment variable

--- a/apps/relay/src/logger.ts
+++ b/apps/relay/src/logger.ts
@@ -1,5 +1,7 @@
+import { LOG_LEVEL } from "./env";
+
 export const logger = {
-  level: "info",
+  level: LOG_LEVEL,
   redact: [
     "req.headers.authorization",
     'req.headers["x-farcaster-auth-relay-key"]',


### PR DESCRIPTION
## Motivation

We were hard coding this previously to `info`. Allow it to be customized.

## Change Summary

Allow log level to be configured using LOG_LEVEL envar.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
