### PR TITLE
Fix typos

### DIFF
--- a/packages/auth-client/README.md
+++ b/packages/auth-client/README.md
@@ -333,7 +333,7 @@ Example: `"0x9335c3055d4778013fdabad293c68c84ea350a11794cdc121c71fd51b[...]"`
 
 If you're building a [wallet app](https://docs.farcaster.xyz/learn/what-is-farcaster/apps#wallet-apps) and receiving signature requests, use a _wallet client_.
 
-You can use an wallet client to parse an incoming Sign In With Farcaster request URL, build a Sign In With Farcaster message to present to the user, and submit the signed message to a Farcaster Auth relay channel.
+You can use a wallet client to parse an incoming Sign In With Farcaster request URL, build a Sign In With Farcaster message to present to the user, and submit the signed message to a Farcaster Auth relay channel.
 
 ```ts
 import { createWalletClient, viemConnector } from "@farcaster/auth-client";

--- a/packages/auth-client/README.md
+++ b/packages/auth-client/README.md
@@ -1,6 +1,6 @@
 # `@farcaster/auth-client`
 
-A framework agnostic client library for Farcaster Auth.
+A framework-agnostic client library for Farcaster Auth.
 
 ## Getting Started
 


### PR DESCRIPTION
This PR addresses minor typographical issues and improves phrasing in the `README.md` file of the `auth-client` package. These changes enhance the readability and accuracy of the documentation.  

## Change Summary  
- Corrected "framework agnostic" to "framework-agnostic" for consistency and adherence to standard English.  
- Replaced "an wallet client" with "a wallet client" to use the proper article.  

## Merge Checklist  
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.  
- [ ] PR has a changeset.  
- [x] PR has been tagged with a change label(s) (documentation).  
- [ ] PR includes documentation if necessary.  
- [ ] All commits have been signed.  

## Additional Context  
These changes are minimal but improve the clarity and professionalism of the documentation for developers using the `auth-client` library.  
