### PR TITLE
fix: useSignIn signIn method not working

### DIFF
--- a/packages/auth-kit/src/hooks/useSignIn.ts
+++ b/packages/auth-kit/src/hooks/useSignIn.ts
@@ -90,6 +90,12 @@ export function useSignIn(args: UseSignInArgs) {
     }
   }, [isSuccess, statusData, validSignature, onSignIn, onSuccess]);
 
+  useEffect(() => {
+    if (!channelToken) {
+      connect();
+    }
+  }, [channelToken, connect]);
+
   return {
     signIn,
     signOut,


### PR DESCRIPTION
## Motivation


Key change:
This pull request includes a change to the useSignIn hook in the packages/auth-kit/src/hooks/useSignIn.ts file. The change ensures that the connect function is called when the channelToken is not available. Without the channelToken, the signIn method from useSignIn does not work.
- https://github.com/farcasterxyz/auth-monorepo/issues/198
- https://github.com/farcasterxyz/auth-monorepo/issues/156

## Change Summary

Additional useEffect hook was included in useSignIn hook. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
