### PR TITLE
chore: skip Docker login for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: yarn build
 
       - name: Log in to Docker Hub to avoid rate limiting
+        if: secrets.FARCASTERXYZ_DOCKER_HUB_TOKEN != ''
         uses: docker/login-action@v2
         with:
           username: ${{ vars.FARCASTERXYZ_DOCKER_HUB_USER }}


### PR DESCRIPTION
## Motivation

Dependabot can't access our CI secrets. 

## Change Summary

Skip Dockerhub login for Dependabot PRs.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
