### PR TITLE
fix: consistent plugin registration styles

### DIFF
--- a/.changeset/thirty-pumas-walk.md
+++ b/.changeset/thirty-pumas-walk.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/auth-relay": patch
+---
+
+fix: use consistent plugin registration style

--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -51,18 +51,17 @@ export class RelayServer {
 
   initHandlers() {
     this.app.register(
-      (v1, _opts, next) => {
-        v1.register(async (publicRoutes, _opts, next) => {
+      async (v1, _opts) => {
+        await v1.register(async (publicRoutes, _opts) => {
           await publicRoutes.register(rateLimit);
           publicRoutes.post<{ Body: CreateChannelRequest }>(
             "/channel",
             { schema: { body: createChannelRequestSchema } },
             createChannel,
           );
-          next();
         });
 
-        v1.register((protectedRoutes, _opts, next) => {
+        await v1.register(async (protectedRoutes, _opts) => {
           protectedRoutes.decorateRequest("channelToken", "");
           protectedRoutes.addHook("preHandler", async (request, reply) => {
             const auth = request.headers.authorization;
@@ -79,10 +78,7 @@ export class RelayServer {
           }>("/channel/authenticate", { schema: { body: authenticateRequestSchema } }, authenticate);
 
           protectedRoutes.get("/channel/status", status);
-
-          next();
         });
-        next();
       },
       { prefix: "/v1" },
     );


### PR DESCRIPTION
## Change Summary

Use async/await style for plugin registration. (Fixes mixed style warning at startup)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed
