### PR TITLE
Extract base64url encoding/decoding into separate utility

### DIFF
--- a/packages/jfs/src/index.ts
+++ b/packages/jfs/src/index.ts
@@ -1,5 +1,6 @@
 import { type Hex, isAddress, verifyMessage, isHex, hexToBytes } from "viem";
 import { ed25519 } from "@noble/curves/ed25519";
+import { toBase64Url, fromBase64Url } from "./utils";
 
 const jsonFarcasterSignatureTypes = ["app_key", "auth", "custody"] as const;
 
@@ -46,27 +47,27 @@ export function uncompact(value: string): JsonFarcasterSignature {
 }
 
 export function encodeHeader(header: JsonFarcasterSignatureHeader): string {
-  return Buffer.from(JSON.stringify(header), "utf-8").toString("base64url");
+  return toBase64Url(Buffer.from(JSON.stringify(header), "utf-8").toString("base64"));
 }
 
 export function encodePayload<TPayload>(payload: TPayload): string {
-  return Buffer.from(JSON.stringify(payload), "utf-8").toString("base64url");
+  return toBase64Url(Buffer.from(JSON.stringify(payload), "utf-8").toString("base64"));
 }
 
 export function encodeSignature(signature: Uint8Array): string {
-  return Buffer.from(signature).toString("base64url");
+  return toBase64Url(Buffer.from(signature).toString("base64"));
 }
 
 export function decodeHeader(header: string): JsonFarcasterSignatureHeader {
-  return JSON.parse(Buffer.from(header, "base64url").toString("utf-8"));
+  return JSON.parse(Buffer.from(fromBase64Url(header), "base64").toString("utf-8"));
 }
 
 export function decodePayload<TPayload>(payload: string): TPayload {
-  return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8"));
+  return JSON.parse(Buffer.from(fromBase64Url(payload), "base64").toString("utf-8"));
 }
 
 export function decodeSignature(signature: string): Uint8Array {
-  return new Uint8Array(Buffer.from(signature, "base64url"));
+  return new Uint8Array(Buffer.from(fromBase64Url(signature), "base64"));
 }
 
 export function decode<TPayload>(input: JsonFarcasterSignature | string): DecodedJsonFarcasterSignature<TPayload> {
@@ -78,9 +79,11 @@ export function decode<TPayload>(input: JsonFarcasterSignature | string): Decode
     return input;
   })();
 
-  const header = JSON.parse(Buffer.from(data.header, "base64url").toString("utf-8"));
-  const payload = data.payload ? JSON.parse(Buffer.from(data.payload, "base64url").toString("utf-8")) : undefined;
-  const signature = new Uint8Array(Buffer.from(data.signature, "base64url"));
+  const header = JSON.parse(Buffer.from(fromBase64Url(data.header), "base64").toString("utf-8"));
+  const payload = data.payload
+    ? JSON.parse(Buffer.from(fromBase64Url(data.payload), "base64").toString("utf-8"))
+    : undefined;
+  const signature = new Uint8Array(Buffer.from(fromBase64Url(data.signature), "base64"));
 
   return {
     header,

--- a/packages/jfs/src/utils.ts
+++ b/packages/jfs/src/utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Custom base64url encoding utilities for browser compatibility.
+ *
+ * Node.js Buffer supports 'base64url' encoding natively, but this is not
+ * available in browser environments. These utilities provide manual conversion
+ * between base64 and base64url formats to ensure the library works in both
+ * Node.js and web browsers.
+ *
+ * Base64url is a URL-safe variant of base64 that:
+ * - Replaces '+' with '-'
+ * - Replaces '/' with '_'
+ * - Removes padding '=' characters
+ */
+
+export function toBase64Url(base64: string): string {
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function fromBase64Url(base64url: string): string {
+  let base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+
+  // Add padding if needed
+  const padding = base64.length % 4;
+  if (padding) {
+    base64 += "=".repeat(4 - padding);
+  }
+
+  return base64;
+}

--- a/packages/jfs/test/utils.test.ts
+++ b/packages/jfs/test/utils.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { toBase64Url, fromBase64Url } from "../src/utils.js";
+
+describe("toBase64Url", () => {
+  it("default: converts base64 to base64url", () => {
+    // Test string that produces all special characters in base64
+    const testString = "Sure. Base64 encoding test!?>";
+    const base64 = Buffer.from(testString).toString("base64");
+    const expected = Buffer.from(testString).toString("base64url");
+
+    const result = toBase64Url(base64);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: handles strings with + and /", () => {
+    const base64 = "SGVsbG8+Pz8/";
+    const expected = "SGVsbG8-Pz8_";
+
+    const result = toBase64Url(base64);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: removes padding", () => {
+    const base64 = "SGVsbG8=";
+    const expected = "SGVsbG8";
+
+    const result = toBase64Url(base64);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: removes multiple padding characters", () => {
+    const base64 = "SGVsbA==";
+    const expected = "SGVsbA";
+
+    const result = toBase64Url(base64);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: handles empty string", () => {
+    const result = toBase64Url("");
+    expect(result).toEqual("");
+  });
+});
+
+describe("fromBase64Url", () => {
+  it("default: converts base64url to base64", () => {
+    // Test string that produces all special characters in base64
+    const testString = "Sure. Base64 encoding test!?>";
+    const base64url = Buffer.from(testString).toString("base64url");
+    const expected = Buffer.from(testString).toString("base64");
+
+    const result = fromBase64Url(base64url);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: handles strings with - and _", () => {
+    const base64url = "SGVsbG8-Pz8_";
+    const expected = "SGVsbG8+Pz8/";
+
+    const result = fromBase64Url(base64url);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: adds single padding", () => {
+    const base64url = "SGVsbG8";
+    const expected = "SGVsbG8=";
+
+    const result = fromBase64Url(base64url);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: adds double padding", () => {
+    const base64url = "SGVsbA";
+    const expected = "SGVsbA==";
+
+    const result = fromBase64Url(base64url);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: no padding needed when length is multiple of 4", () => {
+    const base64url = "SGVsbG8gV29ybGQ";
+    const expected = "SGVsbG8gV29ybGQ=";
+
+    const result = fromBase64Url(base64url);
+    expect(result).toEqual(expected);
+  });
+
+  it("default: handles empty string", () => {
+    const result = fromBase64Url("");
+    expect(result).toEqual("");
+  });
+});
+
+describe("toBase64Url and fromBase64Url roundtrip", () => {
+  it("default: roundtrip with various test strings", () => {
+    const testStrings = [
+      "Hello, World!",
+      "The quick brown fox jumps over the lazy dog",
+      "1234567890",
+      "!@#$%^&*()_+-=[]{}|;':\",./<>?",
+      "🚀 Unicode test 你好世界",
+      "",
+      "a",
+      "ab",
+      "abc",
+      "abcd",
+    ];
+
+    testStrings.forEach((testString) => {
+      const base64 = Buffer.from(testString).toString("base64");
+      const base64url = toBase64Url(base64);
+      const backToBase64 = fromBase64Url(base64url);
+
+      expect(backToBase64).toEqual(base64);
+
+      // Also verify it matches Node.js implementation
+      const nodeBase64url = Buffer.from(testString).toString("base64url");
+      expect(base64url).toEqual(nodeBase64url);
+    });
+  });
+
+  it("default: roundtrip with binary data", () => {
+    const binaryData = new Uint8Array([0, 1, 2, 3, 255, 254, 253, 252]);
+    const base64 = Buffer.from(binaryData).toString("base64");
+    const base64url = toBase64Url(base64);
+    const backToBase64 = fromBase64Url(base64url);
+
+    expect(backToBase64).toEqual(base64);
+
+    // Verify it matches Node.js implementation
+    const nodeBase64url = Buffer.from(binaryData).toString("base64url");
+    expect(base64url).toEqual(nodeBase64url);
+  });
+});


### PR DESCRIPTION
# Fix base64url encoding compatibility for browser environments

## Motivation

The JFS package was using Node.js's native `base64url` encoding which is not available in browser environments, causing `TypeError: Unknown encoding: base64url` when importing the package in web applications. This prevents the library from being used in client-side applications, limiting its adoption and usability.

## Change Summary

Replace Node.js-specific `base64url` encoding with custom utility functions that manually convert between base64 and base64url formats, ensuring cross-platform compatibility between Node.js and browser environments.

## Additional Context

This change introduces:

1. **New utility file (`src/utils.ts`)** with custom base64url encoding functions:
   - `toBase64Url()`: Converts base64 to base64url format
   - `fromBase64Url()`: Converts base64url back to base64 format

2. **Updated core functions** in `src/index.ts` to use the new utilities instead of Node.js `base64url` encoding

3. **Comprehensive test suite** (`test/utils.test.ts`) with 13 test cases that verify:
   - Correct character replacement (`+` → `-`, `/` → `_`)
   - Proper padding handling
   - Roundtrip compatibility
   - Exact matching with Node.js native implementation

The implementation maintains full backward compatibility while enabling browser support. All existing tests continue to pass, ensuring no breaking changes to the API.