### PR TITLE
Fix typo in JFS custody signatures documentation

### DIFF
--- a/packages/jfs/src/index.ts
+++ b/packages/jfs/src/index.ts
@@ -111,7 +111,7 @@ export async function verify({
 
   /**
    * In an early implementation of JFS custody signatures were incorrectly
-   * serialized. If strict is not enabled these signatures will be accpeted.
+   * serialized. If strict is not enabled these signatures will be accepted.
    *
    * @default false
    */


### PR DESCRIPTION
## Motivation


Corrected a minor typo in the documentation comment for the verify function in jfs/src/index.ts. Changed "acpeted" to "accepted" for clarity and accuracy. 